### PR TITLE
Strengthen lower bound

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ libdavenport_la_SOURCES = \
   network.c network.h \
   davenport.c davenport.h \
   lower_bound.c lower_bound.h \
+  preference_graph.c preference_graph.h \
   preflow_push.c preflow_push.h \
   ranking.c ranking.h \
   solution_graph.c solution_graph.h \

--- a/src/davenport.c
+++ b/src/davenport.c
@@ -150,7 +150,7 @@ void dv_extend_solution(Davenport *d)
   if (e_cur < d->edge_ct) {
     int lower_bound = solution_graph_disagreements(d->solution_graph) +
       d->cycle_lower_bounds;
-    if (solution_graph_disagreements(d->solution_graph) <= d->best_found)
+    if (lower_bound <= d->best_found)
     {
       while(e_cur < d->edge_ct) {
         int edge_offset = d->edge_list[e_cur];

--- a/src/davenport.h
+++ b/src/davenport.h
@@ -36,6 +36,7 @@ typedef struct Davenport {
   int best_found;
   DavenportSolutionCallback solution_callback;
   void *solution_context;
+  int cycle_lower_bounds;
 } Davenport;
 
 /*

--- a/src/lower_bound.h
+++ b/src/lower_bound.h
@@ -4,6 +4,8 @@
 #include "network.h"
 #include "preflow_push.h"
 
+typedef int (*LBNetworkEdgeLookup)(void *context, int u, int v, int node_ct);
+
 // defined here for testing; internal use only
 typedef struct {
   int node_ct;
@@ -27,15 +29,22 @@ typedef struct {
   (RCI(c2_index(lb_net, v), t_index(lb_net), lb_net->net_ct))
 
 /*
- This is the public interface.
-
  Given the pair-wise majority graph as "majority" with node_ct nodes
  and a list of indexes within that graph, "component" with component_sz
  indexes (0 <= index < node_ct),
  compute the lower bound on the number of pair-wise rankings
  that must be broken in order to create a non-cyclic majority graph
 */
-int compute_lower_bound(const int *majority, int node_ct,
+int compute_lower_bound(int *majority, int node_ct,
+  const int *component, int component_sz);
+
+/*
+ Given edge weight lookup function into square graph of node_ct nodes and a
+ list of indexes within that graph, "component" with component_sz indexes
+ (0 <= index < node_ct), compute the lower bound on the number of pair-wise
+ rankings that must be broken in order to create a non-cyclic majority graph.
+*/
+int compute_bound_edge_lookup(LBNetworkEdgeLookup, void *context, int node_ct,
   const int *component, int component_sz);
 
 #endif

--- a/src/preference_graph.c
+++ b/src/preference_graph.c
@@ -19,7 +19,8 @@ void preference_graph_add_preference(int *preference_graph,
 void preference_graph_to_majority_graph(const int *preference_graph,
   int *majority_graph, int node_ct)
 {
-  for (int u = 0; u < node_ct - 1; ++u) {
+  for (int u = 0; u < node_ct; ++u) {
+    majority_graph[RCI(u,u,node_ct)] = 0;
     for (int v = u + 1; v < node_ct; ++v) {
       int diff = preference_graph[RCI(u,v,node_ct)] -
         preference_graph[RCI(v,u,node_ct)];
@@ -28,6 +29,10 @@ void preference_graph_to_majority_graph(const int *preference_graph,
       }
       if (diff < 0) {
         majority_graph[RCI(v,u,node_ct)] = -diff;
+      }
+      if (diff == 0) {
+        majority_graph[RCI(v,u,node_ct)] =
+          majority_graph[RCI(u,v,node_ct)] = 0;
       }
     }
   }

--- a/src/preference_graph.c
+++ b/src/preference_graph.c
@@ -15,3 +15,20 @@ void preference_graph_add_preference(int *preference_graph,
     }
   }
 }
+
+void preference_graph_to_majority_graph(const int *preference_graph,
+  int *majority_graph, int node_ct)
+{
+  for (int u = 0; u < node_ct - 1; ++u) {
+    for (int v = u + 1; v < node_ct; ++v) {
+      int diff = preference_graph[RCI(u,v,node_ct)] -
+        preference_graph[RCI(v,u,node_ct)];
+      if (0 < diff) {
+        majority_graph[RCI(u,v,node_ct)] = diff;
+      }
+      if (diff < 0) {
+        majority_graph[RCI(v,u,node_ct)] = -diff;
+      }
+    }
+  }
+}

--- a/src/preference_graph.c
+++ b/src/preference_graph.c
@@ -1,0 +1,17 @@
+#include "network.h"
+#include "preference_graph.h"
+
+void preference_graph_add_preference(int *preference_graph,
+  const int *rankings, int node_ct)
+{
+  for (int u = 0; u < node_ct - 1; ++u) {
+    for (int v = u + 1; v < node_ct; ++v) {
+      if (rankings[u] < rankings[v]) {
+        preference_graph[RCI(u,v,node_ct)] += 1;
+      }
+      if (rankings[v] < rankings[u]) {
+        preference_graph[RCI(v,u,node_ct)] += 1;
+      }
+    }
+  }
+}

--- a/src/preference_graph.h
+++ b/src/preference_graph.h
@@ -15,4 +15,18 @@
 void preference_graph_add_preference(int *preference_graph,
   const int *rankings, int node_ct);
 
+/*
+ Initialize a majority graph from a preference graph
+ Writes majority_graph[u,v] = preference_graph[u,v] - preference_graph[v,u]
+   when preference_graph[u,v] > preference_graph[v,u], otherwise writes
+   majority_graph[u,v] to zero.
+ node_ct: is the number of nodes represented by the preference graph
+ preference_graph: read by the call, edge array allocated to minimum
+   ECT(node_ct) integers, size ESZ(node_ct)
+ majority_graph: modified by the call, edge array allocated to minimum
+   ECT(node_ct) integers, size ESZ(node_ct)
+*/
+void preference_graph_to_majority_graph(const int *preference_graph,
+  int *majority_graph, int node_ct);
+
 #endif

--- a/src/preference_graph.h
+++ b/src/preference_graph.h
@@ -1,0 +1,18 @@
+#ifndef PREFERENCE_GRAPH_H
+#define PREFERENCE_GRAPH_H
+
+/*
+ Add rankings to preference graph
+ Where rankings[u] < rankings[v] we increment preference_graph[u,v] by one.
+   Ranks are numbered in order of preference. A lower number rank is preferred
+   to higher number rank. They are as in "First, second, third, ...".
+ node_ct: is the number of nodes represented by the preference graph
+ preference_graph: modified by the call, edge array allocated to minimum
+   ECT(node_ct) integers, size ESZ(node_ct)
+ rankings: read by the call, node array allocated to minimum node_ct integers,
+   size NSZ(node_ct)
+*/
+void preference_graph_add_preference(int *preference_graph,
+  const int *rankings, int node_ct);
+
+#endif

--- a/src/preflow_push.c
+++ b/src/preflow_push.c
@@ -100,8 +100,9 @@ void saturate_from_source(const int *capacity, int *flow, int *excess,
   int node_ct, int source)
 {
   excess[source] = INT_MAX;
-  for(int v = 0; v < node_ct; ++v)
+  for(int v = 0; v < node_ct; ++v) {
     push(capacity, flow, excess, node_ct, source, v);
+  }
   excess[source] = 0;
 }
 
@@ -211,6 +212,7 @@ int max_flow_reduced_caps(PreflowPush *pp, int *flow, int *labels,
 {
   assert(source < pp->node_ct);
   assert(sink < pp->node_ct);
+  assert(source != sink);
   reset(pp);
   saturate_from_source(pp->capacity, flow, pp->excess, pp->node_ct, source);
   initialize_list(pp->sequence, pp->node_ct, source, sink);

--- a/src/solution_graph.c
+++ b/src/solution_graph.c
@@ -82,14 +82,13 @@ unsigned char solution_graph_has_edge(SolutionGraph *sol, int r, int c)
    return sol->solution[RCI(r,c,sol->node_ct)];
 }
 
-unsigned char solution_graph_has_majority_edge(SolutionGraph *sol,
-  int r, int c)
+int solution_graph_modified_majority_edge(SolutionGraph *sol, int r, int c)
 {
-  return(
-    sol->solution[RCI(r,c,sol->node_ct)] != 0 ||
-    (sol->solution[RCI(c,r,sol->node_ct)] == 0 &&
-      sol->majority_graph[RCI(r,c,sol->node_ct)] != 0)
-  );
+  int weight = 0;
+  if (sol->solution[RCI(c,r,sol->node_ct)] == 0) {
+    weight = sol->majority_graph[RCI(r,c,sol->node_ct)];
+  }
+  return weight;
 }
 
 int solution_graph_disagreements(SolutionGraph *sol)

--- a/src/solution_graph.h
+++ b/src/solution_graph.h
@@ -56,15 +56,12 @@ void solution_graph_rollback(SolutionGraph *sol, int set_point);
 unsigned char solution_graph_has_edge(SolutionGraph *sol, int u, int v);
 
 /*
- Returns presence of an edge directed from u to v in the modified majority
- graph.  The rule is that, if the edge exists in the solution graph, it exists
- in the modified majority graph. Otherwise, if the edge exists in the majority
- graph and the opposite edge is not in the solution graph, then the edge is in
- the modified majority graph.  Treat the return as boolean. Zero value denotes
- no edge.
+ Returns weight of an edge directed from u to v in the modified majority graph.
+ The rule is that, if the edge exists in the majority graph and the opposite
+ edge is not in the solution graph, then the edge is in the modified majority
+ graph.
 */
-unsigned char solution_graph_has_majority_edge(SolutionGraph *sol,
-  int r, int c);
+int solution_graph_modified_majority_edge(SolutionGraph *sol, int r, int c);
 
 /*
  Returns the current disagreement count, which is the total

--- a/src/tarjan.c
+++ b/src/tarjan.c
@@ -45,7 +45,8 @@ Tarjan *tarjan_create(
   t->onstack = malloc(ONSTACK_SIZE(t));
   t->edge_lookup = edge_lookup;
   t->edge_context = edge_context;
-  t->edge_context = edge_context;
+  t->component_callback = NULL;
+  t->component_callback_context = NULL;
 
   tarjan_init(t);
   return t;
@@ -60,6 +61,13 @@ Tarjan *tarjan_destroy(Tarjan *t)
   free(t);
 
   return NULL;
+}
+
+void tarjan_set_component_callback(Tarjan *t,
+  TarjanComponentCallback component_callback, void *context)
+{
+  t->component_callback = component_callback;
+  t->component_callback_context = context;
 }
 
 void tarjan_push(Tarjan *t, int v)
@@ -108,6 +116,10 @@ void tarjan_connect(Tarjan *t, int *components, int v)
       components[w] = t->next_id;
       ++ct;
     } while(w != v);
+    if (t->component_callback != NULL) {
+      t->component_callback(
+        t->component_callback_context, t->stack + t->depth, ct);
+    }
     t->next_id += ct;
   }
 }

--- a/src/tarjan.h
+++ b/src/tarjan.h
@@ -1,7 +1,10 @@
 #ifndef TARJAN_H
 #define TARJAN_H
 
-// defined here for testing
+typedef int (*TarjanEdgeLookup)(
+  void *context, int r, int c, int node_ct);
+typedef void (*TarjanComponentCallback)(
+  void *context, int *component, int member_ct);
 
 typedef struct {
   int node_ct;
@@ -12,11 +15,11 @@ typedef struct {
   int depth;
   int *stack;
   unsigned char *onstack;
-  int (*edge_lookup)(void *context, int r, int c, int node_ct);
+  TarjanEdgeLookup edge_lookup;
   void *edge_context;
+  TarjanComponentCallback component_callback;
+  void *component_callback_context;
 } Tarjan;
-
-// public interface
 
 /*
  Create Tarjan reusable data structure for node_ct components.
@@ -24,7 +27,7 @@ typedef struct {
  there is a directed edge in the edge_context from r to c.
 */
 Tarjan *tarjan_create(
-  int (*edge_lookup)(void *context, int r, int c, int node_ct),
+  TarjanEdgeLookup edge_lookup,
   void *edge_context,
   int node_ct);
 
@@ -33,6 +36,15 @@ Tarjan *tarjan_create(
  Always returns NULL
 */
 Tarjan *tarjan_destroy(Tarjan *tarjan);
+
+/*
+ Record a callback that the algorithm calls on each component when identified.
+ The callback receives the context, an array of integer offsets that identify
+ graph vertices that belong to the component, and the count of vertices in the
+ component.
+*/
+void tarjan_set_component_callback(Tarjan *tarjan,
+  TarjanComponentCallback component_callback, void *context);
 
 /*
  An edge lookup that accepts an integer array as context and returns

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -40,6 +40,7 @@ test_davenport_la_SOURCES = \
   test_sort_edges.c \
   test_sort_nodes.c \
   test_tarjan.c \
+  test_tarjan_ccb.c \
   test_tarjan_impl.c \
   test_tarjan_mmaj.c \
   test_tarjan_topo.c

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -13,7 +13,10 @@ test_davenport_la_SOURCES = \
   test_helper.c \
   test_helper_nets.c \
   test_helper_pentagons.c \
+  test_helper_pref_nets.c \
   test_davenport.c \
+  test_davenport_cycles.c \
+  test_davenport_callback_context.c \
   test_dv_init_elist.c \
   test_dv_init_solution.c \
   test_lower_bound.c \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -18,6 +18,7 @@ test_davenport_la_SOURCES = \
   test_dv_init_solution.c \
   test_lower_bound.c \
   test_network.c \
+  test_preference_graph.c \
   test_preflow_discharge.c \
   test_preflow_list_mgr.c \
   test_preflow_max_flow.c \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,6 +19,7 @@ test_davenport_la_SOURCES = \
   test_lower_bound.c \
   test_network.c \
   test_preference_graph.c \
+  test_pref_to_maj.c \
   test_preflow_discharge.c \
   test_preflow_list_mgr.c \
   test_preflow_max_flow.c \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -17,6 +17,7 @@ test_davenport_la_SOURCES = \
   test_davenport.c \
   test_davenport_cycles.c \
   test_davenport_callback_context.c \
+  test_davenport_prefs.c \
   test_dv_init_elist.c \
   test_dv_init_solution.c \
   test_lower_bound.c \

--- a/test/test_davenport.c
+++ b/test/test_davenport.c
@@ -6,6 +6,7 @@
 #include "../src/network.h"
 #include "test_helper.h"
 #include "test_davenport.h"
+#include "test_davenport_callback_context.h"
 
 void test_davenport_create(void)
 {
@@ -29,39 +30,6 @@ void test_davenport_create(void)
   d = davenport_destroy(d);
   cut_assert_null(d);
   free(majority_graph);
-}
-
-typedef struct CallbackContext {
-  Davenport *dv;
-  int expected_disagreements;
-  int seen_solution_ct;
-  int *last_solution;
-  int valid_solution_ct;
-  int **valid_solutions;
-} CallbackContext;
-
-void handle_solution(void *context, int *ranking, int node_ct,
-  int disagreement_ct)
-{
-  CallbackContext *cbx = (CallbackContext *)context;
-  cbx->last_solution = ranking;
-  Davenport *dv = cbx->dv;
-  if (disagreement_ct == cbx->expected_disagreements) {
-    ++cbx->seen_solution_ct;
-    unsigned char match = (0 == cbx->valid_solution_ct);
-    int next_valid = 0;
-    while (match == 0 && next_valid < cbx->valid_solution_ct) {
-      int cmp = memcmp(cbx->valid_solutions[next_valid], ranking, NSZ(node_ct));
-      if (cmp == 0) match = 1;
-      ++next_valid;
-    }
-    cut_assert_true(match,
-      cut_message("Solution matches expected valid solution"));
-  }
-  if (disagreement_ct < cbx->expected_disagreements) {
-    cut_fail("Have %d disagreements; best expected is %d\n", disagreement_ct,
-      cbx->expected_disagreements);
-  }
 }
 
 void test_davenport_compute_small_no_cycles(void)
@@ -97,96 +65,6 @@ void test_davenport_compute_partial_no_cycles(void)
   cut_assert_equal_int(1, solution_ct);
   cut_assert_equal_int(1, d->solution_ct);
   const int expected[node_ct] = {1, 2, 2, 4};
-  int *solution = davenport_last_solution(d);
-  assert_equal_int_array(expected, solution, node_ct);
-
-  d = davenport_destroy(d);
-  free(majority_graph);
-}
-
-void test_davenport_compute_one_cycle_embedded(void)
-{
-  const int node_ct = 5;
-  int *majority_graph = edge_array_calloc(node_ct);
-  set_majority_net_one_cycle_embedded(majority_graph, node_ct);
-
-  Davenport *d = davenport_create(majority_graph, node_ct);
-
-  CallbackContext cbx;
-  cbx.dv = d;
-  cbx.seen_solution_ct = 0;
-  cbx.valid_solutions = malloc(2 * sizeof(int *));
-  int sol1[] = { 1, 2, 3, 4, 5 };
-  int sol2[] = { 1, 4, 2, 3, 5 };
-  cbx.valid_solutions[0] = sol1;
-  cbx.valid_solutions[1] = sol2;
-  cbx.valid_solution_ct = 2;
-  cbx.expected_disagreements = 1;
-
-  davenport_set_solution_callback(d, &handle_solution, &cbx);
-
-  int solution_ct = davenport_compute(d);
-
-  cut_assert_equal_int(cbx.seen_solution_ct, solution_ct);
-  cut_assert_equal_int(cbx.seen_solution_ct, d->solution_ct);
-  int *solution = davenport_last_solution(d);
-  assert_equal_int_array(cbx.last_solution, solution, node_ct);
-
-  free(cbx.valid_solutions);
-  d = davenport_destroy(d);
-  free(majority_graph);
-}
-
-void test_davenport_compute_multi_cycle_embedded(void)
-{
-  const int node_ct = 8;
-  int *majority_graph = edge_array_calloc(node_ct);
-  set_majority_net_multi_cycle_embedded(majority_graph, node_ct);
-
-  Davenport *d = davenport_create(majority_graph, node_ct);
-
-  CallbackContext cbx;
-  cbx.dv = d;
-  cbx.seen_solution_ct = 0;
-  cbx.expected_disagreements = 4;
-  cbx.valid_solution_ct = 0;
-
-  davenport_set_solution_callback(d, &handle_solution, &cbx);
-
-  int solution_ct = davenport_compute(d);
-
-  cut_assert_equal_int(cbx.seen_solution_ct, solution_ct);
-  cut_assert_equal_int(cbx.seen_solution_ct, d->solution_ct);
-  const int expected[node_ct] = {1, 3, 4, 2, 5, 6, 7, 8};
-  int *solution = davenport_last_solution(d);
-  assert_equal_int_array(expected, solution, node_ct);
-
-  d = davenport_destroy(d);
-  free(majority_graph);
-}
-
-void test_davenport_compute_two_embedded_cycles(void)
-{
-  const int node_ct = 8;
-  int *majority_graph = edge_array_calloc(node_ct);
-  set_majority_net_two_embedded_cycles(majority_graph, node_ct);
-  majority_graph[RCI(0,7,node_ct)] = 7;
-
-  Davenport *d = davenport_create(majority_graph, node_ct);
-
-  CallbackContext cbx;
-  cbx.dv = d;
-  cbx.seen_solution_ct = 0;
-  cbx.expected_disagreements = 2;
-  cbx.valid_solution_ct = 0;
-
-  davenport_set_solution_callback(d, &handle_solution, &cbx);
-
-  int solution_ct = davenport_compute(d);
-
-  cut_assert_equal_int(cbx.seen_solution_ct, solution_ct);
-  cut_assert_equal_int(cbx.seen_solution_ct, d->solution_ct);
-  const int expected[node_ct] = {1, 4, 5, 6, 7, 8, 1, 3};
   int *solution = davenport_last_solution(d);
   assert_equal_int_array(expected, solution, node_ct);
 

--- a/test/test_davenport.c
+++ b/test/test_davenport.c
@@ -26,6 +26,7 @@ void test_davenport_create(void)
   clear_int_array(d->solution, node_ct);
   cut_assert_equal_int(INT_MAX, d->best_found);
   cut_assert_null(d->solution_callback);
+  cut_assert_equal_int(0, d->cycle_lower_bounds);
 
   d = davenport_destroy(d);
   cut_assert_null(d);

--- a/test/test_davenport_callback_context.c
+++ b/test/test_davenport_callback_context.c
@@ -1,5 +1,6 @@
 #include <cutter.h>
 #include <string.h>
+#include <stdio.h> // printf
 #include "../src/davenport.h"
 #include "../src/network.h"
 #include "test_davenport_callback_context.h"

--- a/test/test_davenport_callback_context.c
+++ b/test/test_davenport_callback_context.c
@@ -1,6 +1,5 @@
 #include <cutter.h>
 #include <string.h>
-#include <stdio.h> // printf
 #include "../src/davenport.h"
 #include "../src/network.h"
 #include "test_davenport_callback_context.h"

--- a/test/test_davenport_callback_context.c
+++ b/test/test_davenport_callback_context.c
@@ -1,0 +1,29 @@
+#include <cutter.h>
+#include <string.h>
+#include "../src/davenport.h"
+#include "../src/network.h"
+#include "test_davenport_callback_context.h"
+
+void handle_solution(void *context, int *ranking, int node_ct,
+  int disagreement_ct)
+{
+  CallbackContext *cbx = (CallbackContext *)context;
+  cbx->last_solution = ranking;
+  Davenport *dv = cbx->dv;
+  if (disagreement_ct == cbx->expected_disagreements) {
+    ++cbx->seen_solution_ct;
+    unsigned char match = (0 == cbx->valid_solution_ct);
+    int next_valid = 0;
+    while (match == 0 && next_valid < cbx->valid_solution_ct) {
+      int cmp = memcmp(cbx->valid_solutions[next_valid], ranking, NSZ(node_ct));
+      if (cmp == 0) match = 1;
+      ++next_valid;
+    }
+    cut_assert_true(match,
+      cut_message("Solution matches expected valid solution"));
+  }
+  if (disagreement_ct < cbx->expected_disagreements) {
+    cut_fail("Have %d disagreements; best expected is %d\n", disagreement_ct,
+      cbx->expected_disagreements);
+  }
+}

--- a/test/test_davenport_callback_context.h
+++ b/test/test_davenport_callback_context.h
@@ -1,0 +1,16 @@
+#ifndef TEST_DAVENPORT_CALLBACK_CONTEXT_H
+#define TEST_DAVENPORT_CALLBACK_CONTEXT_H
+
+typedef struct CallbackContext {
+  Davenport *dv;
+  int expected_disagreements;
+  int seen_solution_ct;
+  int *last_solution;
+  int valid_solution_ct;
+  int **valid_solutions;
+} CallbackContext;
+
+void handle_solution(void *context, int *ranking, int node_ct,
+  int disagreement_ct);
+
+#endif

--- a/test/test_davenport_cycles.c
+++ b/test/test_davenport_cycles.c
@@ -1,0 +1,99 @@
+#include <cutter.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../src/davenport.h"
+#include "../src/network.h"
+#include "test_helper.h"
+#include "test_davenport.h"
+#include "test_davenport_callback_context.h"
+
+void test_davenport_compute_one_cycle_embedded(void)
+{
+  const int node_ct = 5;
+  int *majority_graph = edge_array_calloc(node_ct);
+  set_majority_net_one_cycle_embedded(majority_graph, node_ct);
+
+  Davenport *d = davenport_create(majority_graph, node_ct);
+
+  CallbackContext cbx;
+  cbx.dv = d;
+  cbx.seen_solution_ct = 0;
+  cbx.valid_solutions = malloc(2 * sizeof(int *));
+  int sol1[] = { 1, 2, 3, 4, 5 };
+  int sol2[] = { 1, 4, 2, 3, 5 };
+  cbx.valid_solutions[0] = sol1;
+  cbx.valid_solutions[1] = sol2;
+  cbx.valid_solution_ct = 2;
+  cbx.expected_disagreements = 1;
+
+  davenport_set_solution_callback(d, &handle_solution, &cbx);
+
+  int solution_ct = davenport_compute(d);
+
+  cut_assert_equal_int(cbx.seen_solution_ct, solution_ct);
+  cut_assert_equal_int(cbx.seen_solution_ct, d->solution_ct);
+  int *solution = davenport_last_solution(d);
+  assert_equal_int_array(cbx.last_solution, solution, node_ct);
+
+  free(cbx.valid_solutions);
+  d = davenport_destroy(d);
+  free(majority_graph);
+}
+
+void test_davenport_compute_multi_cycle_embedded(void)
+{
+  const int node_ct = 8;
+  int *majority_graph = edge_array_calloc(node_ct);
+  set_majority_net_multi_cycle_embedded(majority_graph, node_ct);
+
+  Davenport *d = davenport_create(majority_graph, node_ct);
+
+  CallbackContext cbx;
+  cbx.dv = d;
+  cbx.seen_solution_ct = 0;
+  cbx.expected_disagreements = 4;
+  cbx.valid_solution_ct = 0;
+
+  davenport_set_solution_callback(d, &handle_solution, &cbx);
+
+  int solution_ct = davenport_compute(d);
+
+  cut_assert_equal_int(cbx.seen_solution_ct, solution_ct);
+  cut_assert_equal_int(cbx.seen_solution_ct, d->solution_ct);
+  const int expected[node_ct] = {1, 3, 4, 2, 5, 6, 7, 8};
+  int *solution = davenport_last_solution(d);
+  assert_equal_int_array(expected, solution, node_ct);
+
+  d = davenport_destroy(d);
+  free(majority_graph);
+}
+
+void test_davenport_compute_two_embedded_cycles(void)
+{
+  const int node_ct = 8;
+  int *majority_graph = edge_array_calloc(node_ct);
+  set_majority_net_two_embedded_cycles(majority_graph, node_ct);
+  majority_graph[RCI(0,7,node_ct)] = 7;
+
+  Davenport *d = davenport_create(majority_graph, node_ct);
+
+  CallbackContext cbx;
+  cbx.dv = d;
+  cbx.seen_solution_ct = 0;
+  cbx.expected_disagreements = 2;
+  cbx.valid_solution_ct = 0;
+
+  davenport_set_solution_callback(d, &handle_solution, &cbx);
+
+  int solution_ct = davenport_compute(d);
+
+  cut_assert_equal_int(cbx.seen_solution_ct, solution_ct);
+  cut_assert_equal_int(cbx.seen_solution_ct, d->solution_ct);
+  const int expected[node_ct] = {1, 4, 5, 6, 7, 8, 1, 3};
+  int *solution = davenport_last_solution(d);
+  assert_equal_int_array(expected, solution, node_ct);
+
+  d = davenport_destroy(d);
+  free(majority_graph);
+}

--- a/test/test_davenport_prefs.c
+++ b/test/test_davenport_prefs.c
@@ -1,0 +1,38 @@
+#include <cutter.h>
+#include <stdlib.h>
+#include "../src/davenport.h"
+#include "../src/network.h"
+#include "../src/preference_graph.h"
+#include "test_helper.h"
+#include "test_davenport.h"
+#include "test_davenport_callback_context.h"
+
+void test_davenport_compute_preference_net_1(void)
+{
+  const int node_ct = 5;
+  int *preference_graph = edge_array_calloc(node_ct);
+  int *majority_graph = edge_array_calloc(node_ct);
+  set_preference_net_1(preference_graph, node_ct);
+  preference_graph_to_majority_graph(preference_graph, majority_graph, node_ct);
+
+  Davenport *d = davenport_create(majority_graph, node_ct);
+
+  CallbackContext cbx;
+  cbx.dv = d;
+  cbx.seen_solution_ct = 0;
+  cbx.valid_solution_ct = 1;
+  cbx.valid_solutions = malloc(cbx.valid_solution_ct * sizeof(int *));
+  int r1[] = { 1, 2, 4, 5, 3 };
+  cbx.valid_solutions[0] = r1;
+  cbx.expected_disagreements = 2;
+
+  davenport_set_solution_callback(d, &handle_solution, &cbx);
+
+  int solution_ct = davenport_compute(d);
+  cut_assert_equal_int(cbx.seen_solution_ct, solution_ct);
+
+  free(cbx.valid_solutions);
+  d = davenport_destroy(d);
+  free(majority_graph);
+  free(preference_graph);
+}

--- a/test/test_helper_nets.h
+++ b/test/test_helper_nets.h
@@ -8,4 +8,6 @@ void set_majority_net_multi_cycle_embedded(int *majority, int node_ct);
 void set_majority_net_two_embedded_cycles(int *majority, int node_ct);
 void set_majority_tarjan_example(int *majority, int node_ct);
 
+void set_preference_net_1(int *preference_graph, int node_ct);
+
 #endif

--- a/test/test_helper_pref_nets.c
+++ b/test/test_helper_pref_nets.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include "../src/network.h"
+
+void set_preference_net_1(int *preference_graph, int node_ct)
+{
+  assert(5 <= node_ct);
+  preference_graph[RCI(0,1,node_ct)] = 5;
+  preference_graph[RCI(0,2,node_ct)] = 3;
+  preference_graph[RCI(0,3,node_ct)] = 5;
+  preference_graph[RCI(0,4,node_ct)] = 5;
+  preference_graph[RCI(1,0,node_ct)] = 2;
+  preference_graph[RCI(1,2,node_ct)] = 4;
+  preference_graph[RCI(1,3,node_ct)] = 3;
+  preference_graph[RCI(1,4,node_ct)] = 5;
+  preference_graph[RCI(2,0,node_ct)] = 4;
+  preference_graph[RCI(2,1,node_ct)] = 3;
+  preference_graph[RCI(2,3,node_ct)] = 5;
+  preference_graph[RCI(2,4,node_ct)] = 3;
+  preference_graph[RCI(3,0,node_ct)] = 2;
+  preference_graph[RCI(3,1,node_ct)] = 4;
+  preference_graph[RCI(3,2,node_ct)] = 2;
+  preference_graph[RCI(3,4,node_ct)] = 2;
+  preference_graph[RCI(4,0,node_ct)] = 2;
+  preference_graph[RCI(4,1,node_ct)] = 2;
+  preference_graph[RCI(4,2,node_ct)] = 4;
+  preference_graph[RCI(4,3,node_ct)] = 5;
+}
+

--- a/test/test_lower_bound.c
+++ b/test/test_lower_bound.c
@@ -71,7 +71,8 @@ void test_lb_network_init_capacities(void)
   };
   LBNetwork *lb_net = lb_network_new(component_ct);
 
-  lb_network_init_capacities(lb_net, majority, node_ct, component);
+  lb_network_init_capacities(lb_net, &lower_bound_edge_lookup,
+    majority, node_ct, component);
 
   int *flow_caps = lb_net->capacities;
   cut_assert_equal_int(majority[RCI(offset, offset + 1, node_ct)],
@@ -100,7 +101,8 @@ void test_lb_network_init_for_pass(void)
   LBNetwork *lb_net = lb_network_new(component_ct);
   int u = 0;
 
-  lb_network_init_capacities(lb_net, majority, node_ct, component);
+  lb_network_init_capacities(lb_net, &lower_bound_edge_lookup,
+    majority, node_ct, component);
   // initialize a fake flow, including something on u-u that shouldn't be there
   majority[RCI(u, u, node_ct)] = node_ct;
   for (int v = 0; v < component_ct; ++v) {
@@ -109,7 +111,9 @@ void test_lb_network_init_for_pass(void)
   }
   // spoil s-u and u-t from "prior" run
   lb_net->capacities[s_edge_index(lb_net, u)] = node_ct;
+  lb_net->flows[s_edge_index(lb_net, u)] = node_ct;
   lb_net->capacities[t_edge_index(lb_net, u)] = node_ct;
+  lb_net->flows[t_edge_index(lb_net, u)] = node_ct;
 
   lb_network_init_for_pass(lb_net, u);
 

--- a/test/test_lower_bound.h
+++ b/test/test_lower_bound.h
@@ -6,9 +6,10 @@
 // declare internal methods from lower_bound, for testing
 LBNetwork *lb_network_new(int component_sz);
 LBNetwork *lb_network_destroy(LBNetwork *lb_net);
-void lb_network_init_capacities(LBNetwork *lb_net,
-  const int *majority, int node_ct, const int *component);
+void lb_network_init_capacities(LBNetwork *lb_net, LBNetworkEdgeLookup lookup,
+  void *context, int node_ct, const int *component);
 void lb_network_init_for_pass(LBNetwork *lb_net, int u);
 void lb_network_update_from_pass(LBNetwork *lb_net, int u);
+int lower_bound_edge_lookup(void *context, int u, int v, int node_ct);
 
 #endif

--- a/test/test_pref_to_maj.c
+++ b/test/test_pref_to_maj.c
@@ -36,3 +36,15 @@ void test_preference_graph_convert_majority(void)
   free(majority_graph);
   free(preference_graph);
 }
+
+void test_preference_graph_convert_majority_overwrite(void)
+{
+  int node_ct = 3;
+  int *preference_graph = edge_array_calloc(node_ct);
+  int *majority_graph = edge_array_calloc(node_ct);
+  set_int_array(majority_graph, 1, node_ct);
+
+  preference_graph_to_majority_graph(preference_graph, majority_graph, node_ct);
+
+  assert_equal_int_array(preference_graph, majority_graph, node_ct);
+}

--- a/test/test_pref_to_maj.c
+++ b/test/test_pref_to_maj.c
@@ -8,27 +8,7 @@ void test_preference_graph_convert_majority(void)
   const int node_ct = 5;
   int *preference_graph = edge_array_calloc(node_ct);
   int *majority_graph = edge_array_calloc(node_ct);
-
-  preference_graph[RCI(0,1,node_ct)] = 5;
-  preference_graph[RCI(0,2,node_ct)] = 3;
-  preference_graph[RCI(0,3,node_ct)] = 5;
-  preference_graph[RCI(0,4,node_ct)] = 5;
-  preference_graph[RCI(1,0,node_ct)] = 2;
-  preference_graph[RCI(1,2,node_ct)] = 4;
-  preference_graph[RCI(1,3,node_ct)] = 3;
-  preference_graph[RCI(1,4,node_ct)] = 5;
-  preference_graph[RCI(2,0,node_ct)] = 4;
-  preference_graph[RCI(2,1,node_ct)] = 3;
-  preference_graph[RCI(2,3,node_ct)] = 5;
-  preference_graph[RCI(2,4,node_ct)] = 3;
-  preference_graph[RCI(3,0,node_ct)] = 2;
-  preference_graph[RCI(3,1,node_ct)] = 4;
-  preference_graph[RCI(3,2,node_ct)] = 2;
-  preference_graph[RCI(3,4,node_ct)] = 2;
-  preference_graph[RCI(4,0,node_ct)] = 2;
-  preference_graph[RCI(4,1,node_ct)] = 2;
-  preference_graph[RCI(4,2,node_ct)] = 4;
-  preference_graph[RCI(4,3,node_ct)] = 5;
+  set_preference_net_1(preference_graph, node_ct);
 
   preference_graph_to_majority_graph(preference_graph, majority_graph, node_ct);
 

--- a/test/test_pref_to_maj.c
+++ b/test/test_pref_to_maj.c
@@ -1,0 +1,58 @@
+#include <cutter.h>
+#include "../src/network.h"
+#include "../src/preference_graph.h"
+#include "test_helper.h"
+
+void test_preference_graph_convert_majority(void)
+{
+  const int node_ct = 5;
+  int *preference_graph = edge_array_calloc(node_ct);
+  int *majority_graph = edge_array_calloc(node_ct);
+
+  preference_graph[RCI(0,1,node_ct)] = 5;
+  preference_graph[RCI(0,2,node_ct)] = 3;
+  preference_graph[RCI(0,3,node_ct)] = 5;
+  preference_graph[RCI(0,4,node_ct)] = 5;
+  preference_graph[RCI(1,0,node_ct)] = 2;
+  preference_graph[RCI(1,2,node_ct)] = 4;
+  preference_graph[RCI(1,3,node_ct)] = 3;
+  preference_graph[RCI(1,4,node_ct)] = 5;
+  preference_graph[RCI(2,0,node_ct)] = 4;
+  preference_graph[RCI(2,1,node_ct)] = 3;
+  preference_graph[RCI(2,3,node_ct)] = 5;
+  preference_graph[RCI(2,4,node_ct)] = 3;
+  preference_graph[RCI(3,0,node_ct)] = 2;
+  preference_graph[RCI(3,1,node_ct)] = 4;
+  preference_graph[RCI(3,2,node_ct)] = 2;
+  preference_graph[RCI(3,4,node_ct)] = 2;
+  preference_graph[RCI(4,0,node_ct)] = 2;
+  preference_graph[RCI(4,1,node_ct)] = 2;
+  preference_graph[RCI(4,2,node_ct)] = 4;
+  preference_graph[RCI(4,3,node_ct)] = 5;
+
+  preference_graph_to_majority_graph(preference_graph, majority_graph, node_ct);
+
+  cut_assert_equal_int(3, majority_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(3, majority_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(3, majority_graph[RCI(0,4,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(1, majority_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(3, majority_graph[RCI(1,4,node_ct)]);
+  cut_assert_equal_int(1, majority_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(3, majority_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(2,4,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(1, majority_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(3,2,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(3,4,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(4,0,node_ct)]);
+  cut_assert_equal_int(0, majority_graph[RCI(4,1,node_ct)]);
+  cut_assert_equal_int(1, majority_graph[RCI(4,2,node_ct)]);
+  cut_assert_equal_int(3, majority_graph[RCI(4,3,node_ct)]);
+
+  free(majority_graph);
+  free(preference_graph);
+}

--- a/test/test_preference_graph.c
+++ b/test/test_preference_graph.c
@@ -1,0 +1,256 @@
+#include <cutter.h>
+#include "../src/network.h"
+#include "../src/preference_graph.h"
+#include "test_helper.h"
+
+void test_preference_graph_add_preference(void)
+{
+  const int node_ct = 5;
+  int *preference_graph = edge_array_calloc(node_ct);
+
+  int j1[] = { 5, 4, 2, 3, 1 };
+  preference_graph_add_preference(preference_graph, j1, node_ct);
+  cut_assert_equal_int(0, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(0,4,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(1,4,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,4,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(3,2,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(3,4,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(4,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(4,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(4,2,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(4,3,node_ct)]);
+
+  int j2[] = { 1, 2, 4, 6, 3 };
+  preference_graph_add_preference(preference_graph, j2, node_ct);
+  cut_assert_equal_int(1, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(0,4,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,4,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,4,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(3,2,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(3,4,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(4,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(4,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,3,node_ct)]);
+
+  int j3[] = { 7, 1, 2, 4, 3 };
+  preference_graph_add_preference(preference_graph, j3, node_ct);
+  cut_assert_equal_int(1, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(0,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(3,2,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(3,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(4,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,2,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(4,3,node_ct)]);
+
+  int j4[] = { 1, 3, 5, 2, 4 };
+  preference_graph_add_preference(preference_graph, j4, node_ct);
+  cut_assert_equal_int(2, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(1,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,2,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(4,1,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(4,2,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(4,3,node_ct)]);
+
+  int j5[] = { 2, 5, 1, 4, 3 };
+  preference_graph_add_preference(preference_graph, j5, node_ct);
+  cut_assert_equal_int(3, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(0,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(1,4,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(2,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,2,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,1,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(4,2,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(4,3,node_ct)]);
+
+  int j6[] = { 1, 2, 5, 4, 3 };
+  preference_graph_add_preference(preference_graph, j6, node_ct);
+  cut_assert_equal_int(4, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(0,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(1,4,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(2,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,2,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,1,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(4,2,node_ct)]);
+  cut_assert_equal_int(5, preference_graph[RCI(4,3,node_ct)]);
+
+  int j7[] = { 2, 4, 1, 3, 5 };
+  preference_graph_add_preference(preference_graph, j7, node_ct);
+  cut_assert_equal_int(5, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(5, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(5, preference_graph[RCI(0,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(5, preference_graph[RCI(1,4,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(5, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(3, preference_graph[RCI(2,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,4,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(4,1,node_ct)]);
+  cut_assert_equal_int(4, preference_graph[RCI(4,2,node_ct)]);
+  cut_assert_equal_int(5, preference_graph[RCI(4,3,node_ct)]);
+
+  free(preference_graph);
+}
+
+void test_preference_graph_add_preference_with_ties(void)
+{
+  const int node_ct = 4;
+  int *preference_graph = edge_array_calloc(node_ct);
+
+  int j1[] = { 5, 4, 4, 3 };
+  preference_graph_add_preference(preference_graph, j1, node_ct);
+  cut_assert_equal_int(0, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,2,node_ct)]);
+
+  int j2[] = { 1, 1, 3, 3 };
+  preference_graph_add_preference(preference_graph, j2, node_ct);
+  cut_assert_equal_int(0, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,2,node_ct)]);
+
+  int j3[] = { 1, 2, 3, 3 };
+  preference_graph_add_preference(preference_graph, j3, node_ct);
+  cut_assert_equal_int(1, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(3,2,node_ct)]);
+
+  int j4[] = { 2, 2, 2, 1 };
+  preference_graph_add_preference(preference_graph, j4, node_ct);
+  cut_assert_equal_int(1, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,2,node_ct)]);
+
+  int j5[] = { 1, 1, 1, 1 };
+  preference_graph_add_preference(preference_graph, j5, node_ct);
+  cut_assert_equal_int(1, preference_graph[RCI(0,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(0,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(1,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,2,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(1,3,node_ct)]);
+  cut_assert_equal_int(1, preference_graph[RCI(2,0,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,1,node_ct)]);
+  cut_assert_equal_int(0, preference_graph[RCI(2,3,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,0,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,1,node_ct)]);
+  cut_assert_equal_int(2, preference_graph[RCI(3,2,node_ct)]);
+
+  free(preference_graph);
+}

--- a/test/test_sol_mmaj.c
+++ b/test/test_sol_mmaj.c
@@ -10,8 +10,8 @@ void test_solution_graph_mmaj_no_solution_edge(void)
   set_majority_net_multi_cycle_embedded(majority_graph, node_ct);
   SolutionGraph *sol = solution_graph_create(majority_graph, node_ct);
 
-  cut_assert_true(solution_graph_has_majority_edge(sol, 0, 1));
-  cut_assert_true(solution_graph_has_majority_edge(sol, 4, 3));
+  cut_assert_true(solution_graph_modified_majority_edge(sol, 0, 1));
+  cut_assert_true(solution_graph_modified_majority_edge(sol, 4, 3));
 
   sol = solution_graph_destroy(sol);
   free(majority_graph);
@@ -27,8 +27,8 @@ void test_solution_graph_mmaj_added_solution_edge(void)
   solution_graph_add_edge(sol, 2, 5);
   solution_graph_add_edge(sol, 1, 2);
 
-  cut_assert_true(solution_graph_has_majority_edge(sol, 2, 5));
-  cut_assert_true(solution_graph_has_majority_edge(sol, 1, 5));
+  cut_assert_true(solution_graph_modified_majority_edge(sol, 2, 5));
+  cut_assert_true(solution_graph_modified_majority_edge(sol, 1, 5));
 
   sol = solution_graph_destroy(sol);
   free(majority_graph);
@@ -41,13 +41,13 @@ void test_solution_graph_mmaj_reverse_solution_edge(void)
   set_majority_net_multi_cycle_embedded(majority_graph, node_ct);
   SolutionGraph *sol = solution_graph_create(majority_graph, node_ct);
 
-  cut_assert_true(solution_graph_has_majority_edge(sol, 3, 1));
+  cut_assert_true(solution_graph_modified_majority_edge(sol, 3, 1));
   solution_graph_add_edge(sol, 1, 3);
-  cut_assert_false(solution_graph_has_majority_edge(sol, 3, 1));
+  cut_assert_false(solution_graph_modified_majority_edge(sol, 3, 1));
 
-  cut_assert_true(solution_graph_has_majority_edge(sol, 5, 3));
+  cut_assert_true(solution_graph_modified_majority_edge(sol, 5, 3));
   solution_graph_add_edge(sol, 3, 5);
-  cut_assert_false(solution_graph_has_majority_edge(sol, 5, 3));
+  cut_assert_false(solution_graph_modified_majority_edge(sol, 5, 3));
 
   sol = solution_graph_destroy(sol);
   free(majority_graph);

--- a/test/test_tarjan_ccb.c
+++ b/test/test_tarjan_ccb.c
@@ -1,0 +1,69 @@
+#include <cutter.h>
+#include "test_helper.h"
+#include "../src/network.h"
+#include "../src/tarjan.h"
+
+struct ComponentCallback {
+  unsigned char was_called;
+  int next_id;
+  int *components;
+};
+
+void component_callback(void *context, int *component, int component_sz)
+{
+  struct ComponentCallback *ccb = (struct ComponentCallback *)context;
+  ccb->was_called = 1;
+  ++ccb->next_id;
+  for (int i = 0; i < component_sz; ++i) {
+    ccb->components[component[i]] = ccb->next_id;
+  }
+}
+
+void components_to_precedence(const int *components,
+  int *precedence, int node_ct)
+{
+  for (int u = 0; u < node_ct; ++u) {
+    for (int v = 0; v < node_ct; ++v) {
+      if (u != v && components[u] != components[v]) {
+        precedence[RCI(u,v,node_ct)] = 1;
+      }
+    }
+  }
+}
+
+void test_tarjan_component_callback(void)
+{
+  int node_ct = 8;
+  int *edges = edge_array_calloc(node_ct);
+  struct ComponentCallback ccb;
+  ccb.was_called = 0;
+  ccb.next_id = 0;
+  ccb.components = node_array_calloc(node_ct);
+  int *components = node_array_calloc(node_ct);
+
+  set_majority_net_two_embedded_cycles(edges, node_ct);
+
+  Tarjan *t = tarjan_create(tarjan_default_edge_lookup, edges, node_ct);
+
+  tarjan_set_component_callback(t, &component_callback, &ccb);
+  cut_assert_equal_pointer(&component_callback, t->component_callback);
+  cut_assert_equal_pointer(&ccb, t->component_callback_context);
+
+  tarjan_identify_components(t, components);
+
+  cut_assert_true(ccb.was_called);
+
+  int *ccb_precedence = edge_array_calloc(node_ct);
+  components_to_precedence(ccb.components, ccb_precedence, node_ct);
+  int *tjn_precedence = edge_array_calloc(node_ct);
+  components_to_precedence(components, tjn_precedence, node_ct);
+
+  assert_equal_int_array(tjn_precedence, ccb_precedence, ECT(node_ct));
+
+  free(tjn_precedence);
+  free(ccb_precedence);
+  t = tarjan_destroy(t);
+  free(components);
+  free(ccb.components);
+  free(edges);
+}

--- a/test/test_tarjan_impl.c
+++ b/test/test_tarjan_impl.c
@@ -21,6 +21,8 @@ void test_tarjan_create(void)
   cut_assert_equal_int(0, tarjan->onstack[0]);
   cut_assert_equal_pointer(tarjan_default_edge_lookup, tarjan->edge_lookup);
   cut_assert_equal_pointer(edges, tarjan->edge_context);
+  cut_assert_null(tarjan->component_callback);
+  cut_assert_null(tarjan->component_callback_context);
 
   tarjan = tarjan_destroy(tarjan);
   free(edges);


### PR DESCRIPTION
First add some utilities for generating representative majority graphs from preferences.

Add some tests with representative majority graphs that have cycles.

By "representative" we mean a majority graph that has a corresponding expression as a list of
rankings. Not all graphs represent majority graphs. Not even all that have only one edge between
any two nodes.

The majority graph of `test_davenport_compute_preference_net_1` in `test/test_davenport_prefs.c`, derived from the preference graph of `set_preference_net_1` of `test/test_helper_pref_nets.c` is excellent. It isn't under-constrained like some of the earlier tests, yet contains many cycles. The five alternatives bind together in the majority graph into one component. There are (I think) four cycles of length three and many longer cyclic traversals.

The algorithm produces only one best solution for this graph, with two disagreements. It produces that solution 14,808 times. That number will be the factorial of the number of edges minus alternative edge selections eliminated by transitive closures (where selecting an edge implies other edges).

I'm actually worried that strengthening the lower bound through use of the preflow-push network will slow the algorithm down. The greedy heuristic already drills-in on the lower valued solutions quite rapidly. This seems worth exploring.

This adds a component callback to the Tarjan algorithm. The Davenport algorithm uses this callback to make the lower bound computation on each component using the preflow push network.