### PR TITLE
Define headers for distribution

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,11 +1,9 @@
 lib_LTLIBRARIES = libdavenport.la
-include_HEADERS = \
-  aggregate_solution.h \
-  davenport.h \
-  lower_bound.h \
-  network.h \
-  preference_graph.h \
-  ranking.h
+nobase_include_HEADERS = \
+  davenport/aggregate_solution.h \
+  davenport/davenport.h \
+  davenport/network.h \
+  davenport/preference_graph.h
 
 libdavenport_la_SOURCES = \
   aggregate_solution.c aggregate_solution.h \

--- a/src/aggregate_solution.h
+++ b/src/aggregate_solution.h
@@ -1,52 +1,13 @@
-#ifndef AGGREGATE_SOLUTION_H
-#define AGGREGATE_SOLUTION_H
+#ifndef AGGREGATE_SOLUTION_IMPL_H
+#define AGGREGATE_SOLUTION_IMPL_H
 
-#include "solution_graph.h"
+#include "davenport/aggregate_solution.h"
 
-typedef struct AggregateSolution {
+struct AggregateSolution {
   int node_ct;
   int disagreement_ct;
   int *preference_graph;
   int *aggregate_ranking;
-} AggregateSolution;
-
-/*
- Build a data structure which, with aggregate_solution_add_solution,
- can function as a DavenportSolutionCallback in order to create a composite
- of multiple solutions returned by the Davenport algorithm.
-*/
-AggregateSolution *aggregate_solution_create(int node_ct);
-
-/*
- Free memory allocated for asol to the heap and return NULL
-*/
-AggregateSolution *aggregate_solution_destroy(AggregateSolution *asol);
-
-/*
- Suitable as a DavenportSolutionCallback, collects solutions with
- the latest value for disagreement_ct into a preference graph.
-*/
-void aggregate_solution_add_solution(AggregateSolution *asol,
-  int *sol, int node_ct, int disagreement_ct);
-
-/*
- Use the Tarjan algorithm to find components in the preference graph built-up
- from calls to aggregate_solution_add_solution. This means that rankings
- ...B,C... and ...C,B... cause B and C to show-up as a two-alternative
- component.
-
- Initialize a solution graph from the components and the preference graph, just
- as is done in "Algorithm 1" from the Davenport paper. We use the preference
- graph equivalently to the majority graph, because the inter-component edges
- must necessarily have edges in one direction only (otherwise they would be
- within components).
-
- Make a topological sort of the solution graph and components to produce the
- returned aggregate ranking / partial order.
-
- The returned data is valid until asol is destroyed. It has length
- asol->node_ct.  A subsequent call to this method will overwrite the data.
-*/
-int *aggregate_solution_ranking(AggregateSolution *asol);
+};
 
 #endif

--- a/src/davenport.h
+++ b/src/davenport.h
@@ -1,26 +1,13 @@
-#ifndef DAVENPORT_H
-#define DAVENPORT_H
+#ifndef DAVENPORT_IMPL_H
+#define DAVENPORT_IMPL_H
+
+#include "davenport/davenport.h"
 
 #include "network.h"
 #include "solution_graph.h"
 #include "tarjan.h"
 
-/*
- Callback function invoked when the algorithm finds a solution.
- The context is that supplied by the receiver when the callback was set.
- The ranking is node_ct integers with an index 0 < index <= node_ct for the
- node at the corresponding row or column of the majority graph.
- The disagreement_count is the total of weights from the majority graph
- broken by opposite edges in the solution from which the ranking is derived.
-
- The data within ranking belongs to the caller and will change after
- the callback returns.
-*/
-typedef void (*DavenportSolutionCallback)(
-  void *context, int *ranking, int node_ct, int disagreement_count
-);
-
-typedef struct Davenport {
+struct Davenport {
   int node_ct;
   const int *majority_graph;
   SolutionGraph *solution_graph;
@@ -35,58 +22,6 @@ typedef struct Davenport {
   DavenportSolutionCallback solution_callback;
   void *solution_context;
   int cycle_lower_bounds;
-} Davenport;
-
-/*
- Create data structure for Kemeny order computation.
- Accepts an existing majority graph and count of nodes (alternatives)
- The majority_graph contains integer weights, where the weight at
- RCI(u,v,node_ct) is zero, or represents a majority weight of preference
- for alternative index u over v.
- The caller represents the following:
- - majority_graph has memory allocated to ECT(node_ct) * sizeof(int)
- - that memory is not freed before calling davenport_destroy with the
-   returned pointer to the Davenport data structure.
- - if majority_graph[RCI(u,v,node_ct)] is non-zero, then
-   majority_graph[RCI(v,u,node_ct)] is zero. (There are no reverse edges,
-   nor edges to self.)
-*/
-Davenport *davenport_create(const int *majority_graph, int node_ct);
-
-/*
- Free the storage allocated for Kemeny order computation and the
- data structure used to track it.
- Always returns NULL.
-*/
-Davenport *davenport_destroy(Davenport *d);
-
-/*
- Set a callback that will be invoked with each viable ordering found by the
- algorithm. The value of disagreements will decrease. That is, the callback
- will not be invoked with orderings that have  more disagreements than in prior
- invocations of the callback. However, the algorithm may invoke the callback
- with "best found so far" orderings. It is up to the provider of the callback
- what to do with solutions from any prior invocations that had a greater number
- of disagreements.
-
- The algorithm passes the context pointer in the callback and otherwise
- leaves it entirely under control of the receiver.
-
- This is to keep the algorithm out of the solution management business,
- leaving solution management uncoupled from the core search.
-*/
-void davenport_set_solution_callback(Davenport *d,
-  DavenportSolutionCallback callback, void *context);
-
-/*
- Compute Kemeny-Young partial orders for the current majority graph.
- Returns the count of solutions, also available as d->solution_ct.
-*/
-int davenport_compute(Davenport *d);
-
-/*
- Return the last computed solution
-*/
-int *davenport_last_solution(Davenport *d);
+};
 
 #endif

--- a/src/davenport/aggregate_solution.h
+++ b/src/davenport/aggregate_solution.h
@@ -1,0 +1,45 @@
+#ifndef AGGREGATE_SOLUTION_H
+#define AGGREGATE_SOLUTION_H
+
+typedef struct AggregateSolution AggregateSolution;
+
+/*
+ Build a data structure which, with aggregate_solution_add_solution,
+ can function as a DavenportSolutionCallback in order to create a composite
+ of multiple solutions returned by the Davenport algorithm.
+*/
+AggregateSolution *aggregate_solution_create(int node_ct);
+
+/*
+ Free memory allocated for asol to the heap and return NULL
+*/
+AggregateSolution *aggregate_solution_destroy(AggregateSolution *asol);
+
+/*
+ Suitable as a DavenportSolutionCallback, collects solutions with
+ the latest value for disagreement_ct into a preference graph.
+*/
+void aggregate_solution_add_solution(AggregateSolution *asol,
+  int *sol, int node_ct, int disagreement_ct);
+
+/*
+ Use the Tarjan algorithm to find components in the preference graph built-up
+ from calls to aggregate_solution_add_solution. This means that rankings
+ ...B,C... and ...C,B... cause B and C to show-up as a two-alternative
+ component.
+
+ Initialize a solution graph from the components and the preference graph, just
+ as is done in "Algorithm 1" from the Davenport paper. We use the preference
+ graph equivalently to the majority graph, because the inter-component edges
+ must necessarily have edges in one direction only (otherwise they would be
+ within components).
+
+ Make a topological sort of the solution graph and components to produce the
+ returned aggregate ranking / partial order.
+
+ The returned data is valid until asol is destroyed. It has length
+ asol->node_ct.  A subsequent call to this method will overwrite the data.
+*/
+int *aggregate_solution_ranking(AggregateSolution *asol);
+
+#endif

--- a/src/davenport/davenport.h
+++ b/src/davenport/davenport.h
@@ -1,0 +1,73 @@
+#ifndef DAVENPORT_H
+#define DAVENPORT_H
+
+/*
+ Callback function invoked when the algorithm finds a solution.
+ The context is that supplied by the receiver when the callback was set.
+ The ranking is node_ct integers with an index 0 < index <= node_ct for the
+ node at the corresponding row or column of the majority graph.
+ The disagreement_count is the total of weights from the majority graph
+ broken by opposite edges in the solution from which the ranking is derived.
+
+ The data within ranking belongs to the caller and will change after
+ the callback returns.
+*/
+typedef void (*DavenportSolutionCallback)(
+  void *context, int *ranking, int node_ct, int disagreement_count
+);
+
+typedef struct Davenport Davenport;
+
+/*
+ Create data structure for Kemeny order computation.
+ Accepts an existing majority graph and count of nodes (alternatives)
+ The majority_graph contains integer weights, where the weight at
+ RCI(u,v,node_ct) is zero, or represents a majority weight of preference
+ for alternative index u over v.
+ The caller represents the following:
+ - majority_graph has memory allocated to ECT(node_ct) * sizeof(int)
+ - that memory is not freed before calling davenport_destroy with the
+   returned pointer to the Davenport data structure.
+ - if majority_graph[RCI(u,v,node_ct)] is non-zero, then
+   majority_graph[RCI(v,u,node_ct)] is zero. (There are no reverse edges,
+   nor edges to self.)
+*/
+Davenport *davenport_create(const int *majority_graph, int node_ct);
+
+/*
+ Free the storage allocated for Kemeny order computation and the
+ data structure used to track it.
+ Always returns NULL.
+*/
+Davenport *davenport_destroy(Davenport *d);
+
+/*
+ Set a callback that will be invoked with each viable ordering found by the
+ algorithm. The value of disagreements will decrease. That is, the callback
+ will not be invoked with orderings that have  more disagreements than in prior
+ invocations of the callback. However, the algorithm may invoke the callback
+ with "best found so far" orderings. It is up to the provider of the callback
+ what to do with solutions from any prior invocations that had a greater number
+ of disagreements.
+
+ The algorithm passes the context pointer in the callback and otherwise
+ leaves it entirely under control of the receiver.
+
+ This is to keep the algorithm out of the solution management business,
+ leaving solution management uncoupled from the core search.
+*/
+void davenport_set_solution_callback(Davenport *d,
+  DavenportSolutionCallback callback, void *context);
+
+/*
+ Compute Kemeny-Young partial orders for the current majority graph.
+ Returns the count of solutions, also available as d->solution_ct.
+*/
+int davenport_compute(Davenport *d);
+
+/*
+ Return the last computed solution
+*/
+int *davenport_last_solution(Davenport *d);
+
+#endif

--- a/src/davenport/network.h
+++ b/src/davenport/network.h
@@ -1,0 +1,33 @@
+#ifndef NETWORK_H
+#define NETWORK_H
+
+#include <stdlib.h>
+#include <string.h>
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define RCI(row, col, node_ct) ((row) * (node_ct) + (col))
+#define ROW(index, node_ct) ((index) / (node_ct))
+#define COL(index, node_ct) ((index) % (node_ct))
+#define ECT(node_ct) ((node_ct) * (node_ct))
+#define DG_ECT(node_ct) (ECT(node_ct) / 2)
+
+#define NSZ(node_ct) (node_ct * sizeof(int))
+#define ESZ(node_ct) (ECT(node_ct) * sizeof(int))
+#define DG_ESZ(node_ct) (DG_ECT(node_ct) * sizeof(int))
+
+#define edge_array_calloc(node_ct) calloc(ECT(node_ct), sizeof(int))
+#define edge_array_clear(array, node_ct) memset(array, 0, ESZ(node_ct))
+#define node_array_calloc(node_ct) calloc(node_ct, sizeof(int))
+#define node_array_clear(array, node_ct) memset(array, 0, NSZ(node_ct))
+
+void edge_array_print(const int *edges, int node_ct);
+void edge_array_printl(const int *edges, int node_ct, char *label);
+
+void node_array_print(const int *nodes, int node_ct);
+void node_array_printl(const int *nodes, int node_ct, char *label);
+
+void solution_array_print(const unsigned char *solution, int node_ct);
+void solution_array_printl(const unsigned char *solution,
+  int node_ct, char *label);
+
+#endif

--- a/src/davenport/preference_graph.h
+++ b/src/davenport/preference_graph.h
@@ -1,0 +1,32 @@
+#ifndef PREFERENCE_GRAPH_H
+#define PREFERENCE_GRAPH_H
+
+/*
+ Add rankings to preference graph
+ Where rankings[u] < rankings[v] we increment preference_graph[u,v] by one.
+   Ranks are numbered in order of preference. A lower number rank is preferred
+   to higher number rank. They are as in "First, second, third, ...".
+ node_ct: is the number of nodes represented by the preference graph
+ preference_graph: modified by the call, edge array allocated to minimum
+   ECT(node_ct) integers, size ESZ(node_ct)
+ rankings: read by the call, node array allocated to minimum node_ct integers,
+   size NSZ(node_ct)
+*/
+void preference_graph_add_preference(int *preference_graph,
+  const int *rankings, int node_ct);
+
+/*
+ Initialize a majority graph from a preference graph
+ Writes majority_graph[u,v] = preference_graph[u,v] - preference_graph[v,u]
+   when preference_graph[u,v] > preference_graph[v,u], otherwise writes
+   majority_graph[u,v] to zero.
+ node_ct: is the number of nodes represented by the preference graph
+ preference_graph: read by the call, edge array allocated to minimum
+   ECT(node_ct) integers, size ESZ(node_ct)
+ majority_graph: modified by the call, edge array allocated to minimum
+   ECT(node_ct) integers, size ESZ(node_ct)
+*/
+void preference_graph_to_majority_graph(const int *preference_graph,
+  int *majority_graph, int node_ct);
+
+#endif

--- a/src/network.h
+++ b/src/network.h
@@ -1,33 +1,6 @@
-#ifndef NETWORK_H
-#define NETWORK_H
+#ifndef NETWORK_IMPL_H
+#define NETWORK_IMPL_H
 
-#include <stdlib.h>
-#include <string.h>
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define RCI(row, col, node_ct) ((row) * (node_ct) + (col))
-#define ROW(index, node_ct) ((index) / (node_ct))
-#define COL(index, node_ct) ((index) % (node_ct))
-#define ECT(node_ct) ((node_ct) * (node_ct))
-#define DG_ECT(node_ct) (ECT(node_ct) / 2)
-
-#define NSZ(node_ct) (node_ct * sizeof(int))
-#define ESZ(node_ct) (ECT(node_ct) * sizeof(int))
-#define DG_ESZ(node_ct) (DG_ECT(node_ct) * sizeof(int))
-
-#define edge_array_calloc(node_ct) calloc(ECT(node_ct), sizeof(int))
-#define edge_array_clear(array, node_ct) memset(array, 0, ESZ(node_ct))
-#define node_array_calloc(node_ct) calloc(node_ct, sizeof(int))
-#define node_array_clear(array, node_ct) memset(array, 0, NSZ(node_ct))
-
-void edge_array_print(const int *edges, int node_ct);
-void edge_array_printl(const int *edges, int node_ct, char *label);
-
-void node_array_print(const int *nodes, int node_ct);
-void node_array_printl(const int *nodes, int node_ct, char *label);
-
-void solution_array_print(const unsigned char *solution, int node_ct);
-void solution_array_printl(const unsigned char *solution,
-  int node_ct, char *label);
+#include "davenport/network.h"
 
 #endif

--- a/src/preference_graph.h
+++ b/src/preference_graph.h
@@ -1,32 +1,6 @@
-#ifndef PREFERENCE_GRAPH_H
-#define PREFERENCE_GRAPH_H
+#ifndef PREFERENCE_GRAPH_IMPL_H
+#define PREFERENCE_GRAPH_IMPL_H
 
-/*
- Add rankings to preference graph
- Where rankings[u] < rankings[v] we increment preference_graph[u,v] by one.
-   Ranks are numbered in order of preference. A lower number rank is preferred
-   to higher number rank. They are as in "First, second, third, ...".
- node_ct: is the number of nodes represented by the preference graph
- preference_graph: modified by the call, edge array allocated to minimum
-   ECT(node_ct) integers, size ESZ(node_ct)
- rankings: read by the call, node array allocated to minimum node_ct integers,
-   size NSZ(node_ct)
-*/
-void preference_graph_add_preference(int *preference_graph,
-  const int *rankings, int node_ct);
-
-/*
- Initialize a majority graph from a preference graph
- Writes majority_graph[u,v] = preference_graph[u,v] - preference_graph[v,u]
-   when preference_graph[u,v] > preference_graph[v,u], otherwise writes
-   majority_graph[u,v] to zero.
- node_ct: is the number of nodes represented by the preference graph
- preference_graph: read by the call, edge array allocated to minimum
-   ECT(node_ct) integers, size ESZ(node_ct)
- majority_graph: modified by the call, edge array allocated to minimum
-   ECT(node_ct) integers, size ESZ(node_ct)
-*/
-void preference_graph_to_majority_graph(const int *preference_graph,
-  int *majority_graph, int node_ct);
+#include "davenport/preference_graph.h"
 
 #endif


### PR DESCRIPTION
When trying to use this in the Ruby binding, I found the headers not available after install. Including the headers in the distribution, I found that too many headers had to be there. For implementation, the `struct` definitions are required. For distribution, the type definitions and forward function declarations are enough.

Further, something like "network.h" is way too generic to go directly into, say, `/usr/local/include`; so, the includes to be distributed and their installed locations are now in a subdirectory, `davenport`.

So as not to make a lot of changes in the C files, I left the original implementation header files in place. These include the distribution headers for the forward declarations and typedefs, then go on to add the implementation details where needed. That is generally only the struct definition.