### PR TITLE
Use a varargs initializer in place of {} literal initializer of int arrays

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -10,6 +10,7 @@ test_davenport_la_LIBADD = $(CUTTER_LIBS) $(top_builddir)/src/libdavenport.la
 AM_LDFLAGS = -module -rpath $(libdir) -avoid-version -no-undefined
 
 test_davenport_la_SOURCES = \
+  array_init.c \
   test_aggregate_solution.c \
   test_helper.c \
   test_helper_nets.c \

--- a/test/array_init.c
+++ b/test/array_init.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#include "array_init.h"
+
+void int_array_init(int *a, const int ct, ...) {
+  va_list args;
+  va_start(args, ct);
+  for(int i = 0; i < ct; ++i) {
+    a[i] = va_arg(args, int);
+  }
+  va_end(args);
+}

--- a/test/array_init.h
+++ b/test/array_init.h
@@ -1,0 +1,6 @@
+#ifndef ARRAY_INIT_H
+#define ARRAY_INIT_H
+
+void int_array_init(int *a, const int ct, ...);
+
+#endif

--- a/test/test_davenport.c
+++ b/test/test_davenport.c
@@ -5,6 +5,7 @@
 #include "../src/davenport.h"
 #include "../src/network.h"
 #include "test_helper.h"
+#include "array_init.h"
 #include "test_davenport.h"
 #include "test_davenport_callback_context.h"
 
@@ -46,8 +47,7 @@ void test_davenport_compute_small_no_cycles(void)
   cut_assert_equal_int(1, solution_ct);
   cut_assert_equal_int(1, d->solution_ct);
   int expected[node_ct];
-  int *p = expected;
-  *p++ = 1; *p++ = 2; *p++ = 3; *p++ = 4;
+  int_array_init(expected, node_ct, 1, 2, 3, 4);
   int *solution = davenport_last_solution(d);
   assert_equal_int_array(expected, solution, node_ct);
 
@@ -68,8 +68,7 @@ void test_davenport_compute_partial_no_cycles(void)
   cut_assert_equal_int(1, solution_ct);
   cut_assert_equal_int(1, d->solution_ct);
   int expected[node_ct];
-  int *p = expected;
-  *p++ = 1; *p++ = 2; *p++ = 2; *p++ = 4;
+  int_array_init(expected, node_ct, 1, 2, 2, 4);
   int *solution = davenport_last_solution(d);
   assert_equal_int_array(expected, solution, node_ct);
 

--- a/test/test_davenport_cycles.c
+++ b/test/test_davenport_cycles.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include "../src/davenport.h"
 #include "../src/network.h"
+#include "array_init.h"
 #include "test_helper.h"
 #include "test_davenport.h"
 #include "test_davenport_callback_context.h"
@@ -61,7 +62,8 @@ void test_davenport_compute_multi_cycle_embedded(void)
 
   cut_assert_equal_int(cbx.seen_solution_ct, solution_ct);
   cut_assert_equal_int(cbx.seen_solution_ct, d->solution_ct);
-  const int expected[node_ct] = {1, 3, 4, 2, 5, 6, 7, 8};
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 1, 3, 4, 2, 5, 6, 7, 8);
   int *solution = davenport_last_solution(d);
   assert_equal_int_array(expected, solution, node_ct);
 
@@ -90,7 +92,8 @@ void test_davenport_compute_two_embedded_cycles(void)
 
   cut_assert_equal_int(cbx.seen_solution_ct, solution_ct);
   cut_assert_equal_int(cbx.seen_solution_ct, d->solution_ct);
-  const int expected[node_ct] = {1, 4, 5, 6, 7, 8, 1, 3};
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 1, 4, 5, 6, 7, 8, 1, 3);
   int *solution = davenport_last_solution(d);
   assert_equal_int_array(expected, solution, node_ct);
 

--- a/test/test_dv_init_elist.c
+++ b/test/test_dv_init_elist.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include "../src/davenport.h"
 #include "../src/network.h"
+#include "array_init.h"
 #include "test_helper.h"
 #include "test_davenport.h"
 
@@ -16,7 +17,8 @@ void test_initialize_elist_pentagon_2(void)
 
   const int edge_ct = 7;
   cut_assert_equal_int(edge_ct, d->edge_ct);
-  int expected_weights[edge_ct] = { 3, 3, 3, 2, 2, 2, 2 };
+  int expected_weights[edge_ct];
+  int_array_init(expected_weights, edge_ct, 3, 3, 3, 2, 2, 2, 2);
   for (int i = 0; i < edge_ct; ++ i)
     cut_assert_equal_int(expected_weights[i], majority_graph[d->edge_list[i]]);
 }

--- a/test/test_lower_bound.c
+++ b/test/test_lower_bound.c
@@ -1,6 +1,7 @@
 #include <cutter.h>
-#include "test_helper.h"
 #include "../src/network.h"
+#include "array_init.h"
+#include "test_helper.h"
 #include "test_lower_bound.h"
 
 void populate_connected_component(int *majority, int node_ct, int offset)
@@ -66,9 +67,10 @@ void test_lb_network_init_capacities(void)
   int offset = 2;
   int *majority = edge_array_calloc(node_ct);
   populate_connected_component(majority, node_ct, offset);
-  const int component[component_ct] = {
+  int component[component_ct];
+  int_array_init(component, component_ct,
     offset, offset + 1, offset + 2, offset + 3, offset + 4
-  };
+  );
   LBNetwork *lb_net = lb_network_new(component_ct);
 
   lb_network_init_capacities(lb_net, &lower_bound_edge_lookup,
@@ -97,7 +99,8 @@ void test_lb_network_init_for_pass(void)
   const int component_ct = 5;
   int *majority = edge_array_calloc(node_ct);
   populate_connected_component(majority, node_ct, 0);
-  const int component[component_ct] = {0, 1, 2, 3, 4};
+  int component[component_ct];
+  int_array_init(component, component_ct, 0, 1, 2, 3, 4);
   LBNetwork *lb_net = lb_network_new(component_ct);
   int u = 0;
 
@@ -138,7 +141,8 @@ void test_lb_network_init_for_pass(void)
 void test_lb_network_update_from_pass(void)
 {
   const int component_ct = 5;
-  const int component[component_ct] = {0, 1, 2, 3, 4};
+  int component[component_ct];
+  int_array_init(component, component_ct, 0, 1, 2, 3, 4);
   LBNetwork *lb_net = lb_network_new(component_ct);
   int u = 0;
 
@@ -169,7 +173,8 @@ void test_lower_bound_majority_1(void)
   const int component_ct = 5;
   int *majority = edge_array_calloc(node_ct);
   populate_connected_component(majority, node_ct, 0);
-  const int component[component_ct] = {0, 1, 2, 3, 4};
+  int component[component_ct];
+  int_array_init(component, component_ct, 0, 1, 2, 3, 4);
 
   int lower_bound = compute_lower_bound(majority, node_ct,
     component, component_ct);
@@ -185,9 +190,10 @@ void test_lower_bound_majority_2(void)
   int offset = 2;
   int *majority = edge_array_calloc(node_ct);
   populate_connected_component(majority, node_ct, offset);
-  const int component[component_ct] = {
+  int component[component_ct];
+  int_array_init(component, component_ct,
     offset, offset + 1, offset + 2, offset + 3, offset + 4
-  };
+  );
   draw_majority(majority, node_ct, 0, 1);
   draw_majority(majority, node_ct, 1, 1);
   for (int from = 0; from < (node_ct - 1); ++from) {

--- a/test/test_ranking.c
+++ b/test/test_ranking.c
@@ -1,6 +1,7 @@
 #include <cutter.h>
 #include "../src/network.h"
 #include "../src/solution_graph.h"
+#include "array_init.h"
 #include "test_helper.h"
 
 void test_ranking_order_sorted_complete(void)
@@ -8,7 +9,8 @@ void test_ranking_order_sorted_complete(void)
   const int node_ct = 5;
   int *mg = edge_array_calloc(node_ct);
   SolutionGraph *sol = solution_graph_create(mg, node_ct);
-  int topological_sort[node_ct] = { 0, 1, 2, 3, 4 };
+  int topological_sort[node_ct];
+  int_array_init(topological_sort, node_ct, 0, 1, 2, 3, 4);
 
   for (int i = 1; i < node_ct; ++i) {
     solution_graph_add_edge(sol, i-1, i);
@@ -17,7 +19,8 @@ void test_ranking_order_sorted_complete(void)
   int ranking[node_ct];
   solution_graph_rank_sort_items(sol, topological_sort, ranking);
 
-  int expected[node_ct] = { 1, 2, 3, 4, 5 };
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 1, 2, 3, 4, 5);
   assert_equal_int_array(expected, ranking, node_ct);
 
   solution_graph_destroy(sol);
@@ -29,7 +32,8 @@ void test_ranking_order_sorted_reverse(void)
   const int node_ct = 5;
   int *mg = edge_array_calloc(node_ct);
   SolutionGraph *sol = solution_graph_create(mg, node_ct);
-  int topological_sort[node_ct] = { 4, 3, 2, 1, 0 };
+  int topological_sort[node_ct];
+  int_array_init(topological_sort, node_ct, 4, 3, 2, 1, 0);
 
   for (int i = node_ct - 1; 0 < i; --i) {
     solution_graph_add_edge(sol, i, i - 1);
@@ -38,7 +42,8 @@ void test_ranking_order_sorted_reverse(void)
   int ranking[node_ct];
   solution_graph_rank_sort_items(sol, topological_sort, ranking);
 
-  int expected[node_ct] = { 5, 4, 3, 2, 1 };
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 5, 4, 3, 2, 1);
   assert_equal_int_array(expected, ranking, node_ct);
 
   solution_graph_destroy(sol);
@@ -50,7 +55,8 @@ void test_ranking_order_partial_two_second(void)
   const int node_ct = 5;
   int *mg = edge_array_calloc(node_ct);
   SolutionGraph *sol = solution_graph_create(mg, node_ct);
-  int topological_sort[node_ct] = { 0, 1, 4, 3, 2 };
+  int topological_sort[node_ct];
+  int_array_init(topological_sort, node_ct, 0, 1, 4, 3, 2);
 
   solution_graph_add_edge(sol, 0, 1);
   solution_graph_add_edge(sol, 0, 4);
@@ -60,7 +66,8 @@ void test_ranking_order_partial_two_second(void)
   int ranking[node_ct];
   solution_graph_rank_sort_items(sol, topological_sort, ranking);
 
-  int expected[node_ct] = { 1, 2, 5, 4, 2 };
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 1, 2, 5, 4, 2);
   assert_equal_int_array(expected, ranking, node_ct);
 
   solution_graph_destroy(sol);
@@ -72,7 +79,8 @@ void test_ranking_order_partial_two_first_and_last(void)
   const int node_ct = 5;
   int *mg = edge_array_calloc(node_ct);
   SolutionGraph *sol = solution_graph_create(mg, node_ct);
-  int topological_sort[node_ct] = { 4, 3, 1, 0, 2 };
+  int topological_sort[node_ct];
+  int_array_init(topological_sort, node_ct, 4, 3, 1, 0, 2);
 
   solution_graph_add_edge(sol, 1, 0);
   solution_graph_add_edge(sol, 1, 2);
@@ -82,7 +90,8 @@ void test_ranking_order_partial_two_first_and_last(void)
   int ranking[node_ct];
   solution_graph_rank_sort_items(sol, topological_sort, ranking);
 
-  int expected[node_ct] = { 4, 3, 4, 1, 1 };
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 4, 3, 4, 1, 1);
   assert_equal_int_array(expected, ranking, node_ct);
 
   solution_graph_destroy(sol);
@@ -94,7 +103,8 @@ void test_ranking_order_partial_two_roots(void)
   const int node_ct = 5;
   int *mg = edge_array_calloc(node_ct);
   SolutionGraph *sol = solution_graph_create(mg, node_ct);
-  int topological_sort[node_ct] = { 4, 2, 1, 3, 0 };
+  int topological_sort[node_ct];
+  int_array_init(topological_sort, node_ct, 4, 2, 1, 3, 0);
 
   solution_graph_add_edge(sol, 2, 3);
   solution_graph_add_edge(sol, 2, 1);
@@ -104,7 +114,8 @@ void test_ranking_order_partial_two_roots(void)
   int ranking[node_ct];
   solution_graph_rank_sort_items(sol, topological_sort, ranking);
 
-  int expected[node_ct] = { 5, 3, 1, 3, 1 };
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 5, 3, 1, 3, 1);
   assert_equal_int_array(expected, ranking, node_ct);
 
   solution_graph_destroy(sol);

--- a/test/test_sort_edges.c
+++ b/test/test_sort_edges.c
@@ -1,6 +1,7 @@
 #include <cutter.h>
 #include "../src/network.h"
 #include "../src/sorting.h"
+#include "array_init.h"
 #include "test_helper.h"
 
 void test_sort_edges_1(void) {
@@ -33,11 +34,14 @@ void test_sort_edges_2(void) {
   const int edge_ct = 12;
   const int select_ct = 6;
 
-  int edges[edge_ct] = { 1, 3, 5, 7, 9, 11, 2, 3, 4, 5, 6, 12 };
-  int selection[select_ct] = { 0, 2, 4, 6, 8, 10 };
+  int edges[edge_ct];
+  int_array_init(edges, edge_ct, 1, 3, 5, 7, 9, 11, 2, 3, 4, 5, 6, 12);
+  int selection[select_ct];
+  int_array_init(selection, select_ct, 0, 2, 4, 6, 8, 10);
   sort_edge_selection(edges, selection, select_ct);
 
-  int expected[select_ct] = { 4, 10, 2, 8, 6, 0 };
+  int expected[select_ct];
+  int_array_init(expected, select_ct, 4, 10, 2, 8, 6, 0);
   assert_equal_int_array(expected, selection, select_ct);
 }
 

--- a/test/test_sort_nodes.c
+++ b/test/test_sort_nodes.c
@@ -1,6 +1,7 @@
 #include <cutter.h>
 #include "../src/network.h"
 #include "../src/sorting.h"
+#include "array_init.h"
 #include "test_helper.h"
 
 void test_sort_nodes_1(void) {
@@ -25,11 +26,14 @@ void test_sort_nodes_1(void) {
 void test_sort_nodes_2(void) {
   const int node_ct = 12;
   int *topo_sort = node_array_calloc(node_ct);
-  int topo_positions[node_ct] = { 1, 3, 5, 7, 9, 11, 2, 4, 6, 8, 10, 12 };
+  int topo_positions[node_ct];
+  int_array_init(topo_positions, node_ct,
+    1, 3, 5, 7, 9, 11, 2, 4, 6, 8, 10, 12);
 
   sort_nodes_topo(topo_positions, topo_sort, node_ct);
 
-  int expected[node_ct] = { 11, 5, 10, 4, 9, 3, 8, 2, 7, 1, 6, 0 };
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 11, 5, 10, 4, 9, 3, 8, 2, 7, 1, 6, 0);
   assert_equal_int_array(expected, topo_sort, node_ct);
 
   free(topo_sort);

--- a/test/test_tarjan_topo.c
+++ b/test/test_tarjan_topo.c
@@ -1,4 +1,5 @@
 #include <cutter.h>
+#include "array_init.h"
 #include "test_helper.h"
 #include "../src/network.h"
 #include "../src/tarjan.h"
@@ -14,7 +15,8 @@ void test_tarjan_topo_partial_no_cycles(void)
   tarjan_identify_components(t, components);
   t = tarjan_destroy(t);
 
-  int expected[node_ct] = { 4, 2, 3, 1 };
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 4, 2, 3, 1);
   assert_equal_int_array(expected, components, node_ct);
 
   free(components);
@@ -32,7 +34,8 @@ void test_tarjan_topo_no_cycles(void)
   tarjan_identify_components(t, components);
   t = tarjan_destroy(t);
 
-  int expected[node_ct] = { 4, 3, 2, 1 };
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 4, 3, 2, 1);
   assert_equal_int_array(expected, components, node_ct);
 
   free(components);
@@ -50,7 +53,8 @@ void test_tarjan_topo_two_embedded_cycles(void)
   tarjan_identify_components(t, components);
   t = tarjan_destroy(t);
 
-  int expected[node_ct] = { 8, 5, 5, 5, 2, 2, 2, 1 };
+  int expected[node_ct];
+  int_array_init(expected, node_ct, 8, 5, 5, 5, 2, 2, 2, 1);
   assert_equal_int_array(expected, components, node_ct);
 
   free(components);


### PR DESCRIPTION
Closes #14 

I went with a varargs initializer in `test/array_init` called like,

    const int node_ct = 8;
    int expected[node_ct];
    int_array_init(expected, node_ct, 1, 3, 4, 2, 5, 6, 7, 8);
